### PR TITLE
Reimplementation of CandidateArchive with indices/ID's

### DIFF
--- a/multiLevelCoSurrogates/CandidateArchive.py
+++ b/multiLevelCoSurrogates/CandidateArchive.py
@@ -62,7 +62,7 @@ class CandidateArchive:
 
 
     @classmethod
-    def from_bi_fid_DoE(cls, high_x, low_x, high_y, low_y):
+    def from_bi_fid_doe(cls, high_x, low_x, high_y, low_y):
         """Create a populated CandidateArchive from an existing bi-fidelity DoE
         (high_x, low_x) with corresponding fitness values (high_y, low_y)
         """

--- a/multiLevelCoSurrogates/CandidateArchive.py
+++ b/multiLevelCoSurrogates/CandidateArchive.py
@@ -209,7 +209,9 @@ class CandidateArchive:
 
 
     def _updateminmax(self, fidelity: str, value):
-        if value > self.max[fidelity]:
+        if np.isinf(self.min[fidelity]):
+            self.max[fidelity] = self.min[fidelity] = value
+        elif value > self.max[fidelity]:
             self.max[fidelity] = value
         elif value < self.min[fidelity]:
             self.min[fidelity] = value

--- a/multiLevelCoSurrogates/CandidateArchive.py
+++ b/multiLevelCoSurrogates/CandidateArchive.py
@@ -105,7 +105,7 @@ class CandidateArchive:
                 self._updatecandidate(candidate, fit, fid, verbose=verbose)
 
 
-    def getfitnesses(self, candidates: Iterable, fidelity: Union[str, Iterable[str]]=None) -> Iterable:
+    def getfitnesses(self, candidates: Iterable, fidelity: Union[str, Iterable[str]]) -> Iterable:
         """Return the relevant fitness values for the given candidates"""
 
         fitnesses = np.array([

--- a/multiLevelCoSurrogates/CandidateArchiveNew.py
+++ b/multiLevelCoSurrogates/CandidateArchiveNew.py
@@ -64,7 +64,7 @@ class CandidateArchiveNew:
         """Add candidate, fitness pairs to the archive for given fidelity.
         Will overwrite fitness value if already present.
         """
-        for candidate, fitness in zip(candidates, fitnesses):
+        for candidate, fitness in zip(candidates, np.ravel(fitnesses)):
             self.addcandidate(candidate, fitness, fidelity)
 
 

--- a/multiLevelCoSurrogates/CandidateArchiveNew.py
+++ b/multiLevelCoSurrogates/CandidateArchiveNew.py
@@ -58,9 +58,19 @@ class CandidateArchiveNew:
         pass
 
 
-    def addcandidate(self, *args, **kwargs):
-        """Add a candidate to the archive. Will overwrite fitness value if candidate is already present"""
-        pass
+    def addcandidate(self, candidate, fitness, fidelity=None):
+        """Add a candidate to the archive.
+        Will overwrite fitness value if candidate is already present
+        """
+        try:
+            idx = self.candidates.index(candidate)
+            self.candidates[idx].fidelities[fidelity] = fitness
+
+        except ValueError:
+            # candidates is not yet present
+            new_idx = len(self.candidates)
+            fidelities = {fidelity: fitness}
+            self.candidates.append(Candidate(new_idx, candidate, fidelities))
 
 
     def getfitnesses(self, *args, **kwargs):

--- a/multiLevelCoSurrogates/CandidateArchiveNew.py
+++ b/multiLevelCoSurrogates/CandidateArchiveNew.py
@@ -96,9 +96,13 @@ class CandidateArchiveNew:
         pass
 
 
-    def count(self, *args, **kwargs):
+    def count(self, fidelity: str=None):
         """Count the number of samples archived for the given fidelity"""
-        pass
+        return sum(
+            1
+            for candidate in self.candidates
+            if fidelity in candidate.fidelities
+        )
 
 
     def _addnewcandidate(self, *args, **kwargs):

--- a/multiLevelCoSurrogates/CandidateArchiveNew.py
+++ b/multiLevelCoSurrogates/CandidateArchiveNew.py
@@ -138,9 +138,8 @@ class CandidateArchiveNew:
     def count(self, fidelity: str=None):
         """Count the number of samples archived for the given fidelity"""
         return sum(
-            1
+            fidelity in candidate.fidelities
             for candidate in self.candidates
-            if fidelity in candidate.fidelities
         )
 
 

--- a/multiLevelCoSurrogates/CandidateArchiveNew.py
+++ b/multiLevelCoSurrogates/CandidateArchiveNew.py
@@ -53,14 +53,17 @@ class CandidateArchiveNew:
         return archive
 
 
-    def addcandidates(self, *args, **kwargs):
-        """Add multiple candidates to the archive"""
-        pass
+    def addcandidates(self, candidates, fitnesses, fidelity=None):
+        """Add candidate, fitness pairs to the archive for given fidelity.
+        Will overwrite fitness value if already present.
+        """
+        for candidate, fitness in zip(candidates, fitnesses):
+            self.addcandidate(candidate, fitness, fidelity)
 
 
     def addcandidate(self, candidate, fitness, fidelity=None):
-        """Add a candidate to the archive.
-        Will overwrite fitness value if candidate is already present
+        """Add a candidate, fitness pair to the archive for given fidelity.
+        Will overwrite fitness value if already present
         """
         try:
             idx = self.candidates.index(candidate)

--- a/multiLevelCoSurrogates/CandidateArchiveNew.py
+++ b/multiLevelCoSurrogates/CandidateArchiveNew.py
@@ -72,6 +72,12 @@ class CandidateArchiveNew:
         """Add a candidate, fitness pair to the archive for given fidelity.
         Will overwrite fitness value if already present
         """
+        # unspecified fidelity when explicit fidelities are present raises Error
+        if fidelity is None and len(self.fidelities) >= 1 and fidelity not in self.fidelities:
+            raise ValueError(f'Since explcit fidelities are present, new candidates '
+                             f'cannot be added with implicit fidelity. Fidelities '
+                             f'currently present: {self.fidelities}')
+
         try:
             idx = self.candidates.index(candidate)
             self.candidates[idx].fidelities[fidelity] = fitness

--- a/multiLevelCoSurrogates/CandidateArchiveNew.py
+++ b/multiLevelCoSurrogates/CandidateArchiveNew.py
@@ -30,6 +30,7 @@ class CandidateArchiveNew:
         """Archive of candidates that record fitnessin multiple fidelities"""
         self.candidates = []
         self._update_history = []
+        self._all_fidelities = {}  # dictionary keys used as 'ordered set'
 
 
     @classmethod
@@ -54,6 +55,11 @@ class CandidateArchiveNew:
         return archive
 
 
+    @property
+    def fidelities(self):
+        return self._all_fidelities.keys()
+
+
     def addcandidates(self, candidates, fitnesses, fidelity=None):
         """Add candidate, fitness pairs to the archive for given fidelity.
         Will overwrite fitness value if already present.
@@ -75,6 +81,9 @@ class CandidateArchiveNew:
             new_idx = len(self.candidates)
             fidelities = {fidelity: fitness}
             self.candidates.append(Candidate(new_idx, candidate, fidelities))
+
+        # create key entry if it does not yet exist
+        self._all_fidelities[fidelity] = None
 
 
     def getfitnesses(self, candidates: Iterable, fidelity: Union[str, Iterable[str]]) -> Iterable:
@@ -101,12 +110,18 @@ class CandidateArchiveNew:
 
     def getcandidates(self, *args, **kwargs):
         """Retrieve candidates and fitnesses from the archive.
-
-        :param fidelity:                (optional) Only return candidate and fitness information for the specified fidelities
-        :param num_recent_candidates:   (optional) Only return the last `n` candidates added to the archive
         :return:                        Candidates, Fitnesses (tuple of numpy arrays)
         """
-        pass
+        candidates, fitnesses = [], []
+        for candidate in self.candidates:
+            candidates.append(candidate.x)
+            fitnesses.append(np.ravel([
+                candidate.fidelities.get(fidelity, np.nan)
+                for fidelity in self.fidelities
+            ]))
+            print(fitnesses)
+
+        return CandidateSet(np.array(candidates), np.array(fitnesses))
 
 
     def as_doe(self):

--- a/multiLevelCoSurrogates/CandidateArchiveNew.py
+++ b/multiLevelCoSurrogates/CandidateArchiveNew.py
@@ -7,6 +7,7 @@ CandidateArchiveNew.py: Reimplementation of CandidateArchive to include indices,
 """
 from collections import namedtuple
 from dataclasses import dataclass
+from itertools import chain
 from typing import Iterable, Union
 
 from more_itertools import pairwise
@@ -76,9 +77,44 @@ class CandidateArchiveNew:
             self.candidates.append(Candidate(new_idx, candidate, fidelities))
 
 
-    def getfitnesses(self, *args, **kwargs):
+    def getfitnesses(self, candidates: Iterable, fidelity: Union[str, Iterable[str]]=None) -> Iterable:
         """Return the relevant fitness values for the given candidates"""
-        pass
+
+        # retrieve all candidates by index, fails if candidate is not in archive
+        candidate_indices = [
+            self.candidates.index(candidate)
+            for candidate in candidates
+        ]
+        fidelities = [
+            self.candidates[i].fidelities
+            for i in candidate_indices
+        ]
+
+        print(fidelities)
+
+        if isinstance(fidelity, str):
+            return np.array([
+                fid.get(fidelity, np.nan)
+                for fid in fidelities
+            ]).reshape(-1, 1)
+
+        elif fidelity:
+            return np.array([
+                [fid.get(f, np.nan) for f in fidelity]
+                for fid in fidelities
+            ])
+
+        else:
+            # can probably be cached upon adding candidates...
+            all_fidelities = set()
+            for fid in fidelities:
+                all_fidelities.update(fid.keys())
+            all_fidelities = list(all_fidelities)
+
+            return np.array([
+                [fid.get(f, np.nan) for f in all_fidelities]
+                for fid in fidelities
+            ])
 
 
     def getcandidates(self, *args, **kwargs):
@@ -113,7 +149,11 @@ class CandidateArchiveNew:
         pass
 
 
-    def _updateminmax(self, *args, **kwargs):
+    def _updateminmax(self, value: float, fidelity: str=None):
+        # if value > self.max[fidelity]:
+        #     self.max[fidelity] = value
+        # elif value < self.min[fidelity]:
+        #     self.min[fidelity] = value
         pass
 
 

--- a/multiLevelCoSurrogates/CandidateArchiveNew.py
+++ b/multiLevelCoSurrogates/CandidateArchiveNew.py
@@ -1,0 +1,125 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+CandidateArchiveNew.py: Reimplementation of CandidateArchive to include indices,
+                        be nicer and easier.
+"""
+from collections import namedtuple
+from dataclasses import dataclass
+from typing import Iterable, Union
+
+from more_itertools import pairwise
+
+__author__ = 'Sander van Rijn'
+__email__ = 's.j.van.rijn@liacs.leidenuniv.nl'
+
+
+import numpy as np
+from warnings import warn
+
+import mf2
+from multiLevelCoSurrogates.utils import BiFidelityDoE
+from .CandidateArchive import CandidateSet
+
+
+class CandidateArchiveNew:
+
+    def __init__(self, *args, **kwargs):
+        """Archive of candidates that record fitnessin multiple fidelities"""
+        self.candidates = []
+        self._update_history = []
+
+
+    @classmethod
+    def from_multi_fidelity_function(
+            cls,
+            multi_fid_func: mf2.MultiFidelityFunction,
+            *args,
+            **kwargs
+    ):
+
+        return cls()
+
+
+    @classmethod
+    def from_bi_fid_DoE(cls, high_x, low_x, high_y, low_y):
+        """Create a populated CandidateArchive from an existing bi-fidelity DoE
+        (high_x, low_x) with corresponding fitness values (high_y, low_y)
+        """
+        archive = cls()
+        archive.addcandidates(low_x, low_y, fidelity='low')
+        archive.addcandidates(high_x, high_y, fidelity='high')
+        return archive
+
+
+    def addcandidates(self, *args, **kwargs):
+        """Add multiple candidates to the archive"""
+        pass
+
+
+    def addcandidate(self, *args, **kwargs):
+        """Add a candidate to the archive. Will overwrite fitness value if candidate is already present"""
+        pass
+
+
+    def getfitnesses(self, *args, **kwargs):
+        """Return the relevant fitness values for the given candidates"""
+        pass
+
+
+    def getcandidates(self, *args, **kwargs):
+        """Retrieve candidates and fitnesses from the archive.
+
+        :param fidelity:                (optional) Only return candidate and fitness information for the specified fidelities
+        :param num_recent_candidates:   (optional) Only return the last `n` candidates added to the archive
+        :return:                        Candidates, Fitnesses (tuple of numpy arrays)
+        """
+        pass
+
+
+    def as_doe(self):
+        """Present the stored candidates as a bi-fidelity DoE"""
+        pass
+
+
+    def count(self, *args, **kwargs):
+        """Count the number of samples archived for the given fidelity"""
+        pass
+
+
+    def _addnewcandidate(self, *args, **kwargs):
+        pass
+
+
+    def _updatecandidate(self, *args, **kwargs):
+        pass
+
+
+    def _updateminmax(self, *args, **kwargs):
+        pass
+
+
+    def __contains__(self, val):
+        pass
+
+
+    def __len__(self):
+        return len(self.candidates)
+
+
+    def __index__(self, val):
+        pass
+
+
+@dataclass(eq=False)
+class Candidate:
+    idx: int
+    x: np.ndarray
+    fidelities: dict[str, float]
+
+    def __eq__(self, other):
+        """Check equality only by checking Candidate.x"""
+        if isinstance(other, Candidate):
+            other = other.x
+        return np.all(self.x == other)

--- a/multiLevelCoSurrogates/CandidateArchiveNew.py
+++ b/multiLevelCoSurrogates/CandidateArchiveNew.py
@@ -114,18 +114,27 @@ class CandidateArchiveNew:
         return fitnesses
 
 
-    def getcandidates(self, *args, **kwargs):
+    def getcandidates(self, fidelity=None):
         """Retrieve candidates and fitnesses from the archive.
-        :return:                        Candidates, Fitnesses (tuple of numpy arrays)
+        :fidelity:  (List of) fidelities to select by. Default: all
+        :return:    Candidates, Fitnesses (tuple of numpy arrays)
         """
+        if not fidelity:
+            fidelity = self.fidelities
+        elif isinstance(fidelity, str):
+            fidelity = [fidelity]
+
         candidates, fitnesses = [], []
         for candidate in self.candidates:
-            candidates.append(candidate.x)
-            fitnesses.append(np.ravel([
-                candidate.fidelities.get(fidelity, np.nan)
-                for fidelity in self.fidelities
-            ]))
-            print(fitnesses)
+            fitness = [
+                candidate.fidelities.get(fid, np.nan)
+                for fid in fidelity
+            ]
+
+            # add if any specified fidelities are present for this candidate
+            if np.count_nonzero(~np.isnan(fitness)):
+                fitnesses.append(fitness)
+                candidates.append(candidate.x)
 
         return CandidateSet(np.array(candidates), np.array(fitnesses))
 

--- a/multiLevelCoSurrogates/CandidateArchiveNew.py
+++ b/multiLevelCoSurrogates/CandidateArchiveNew.py
@@ -90,13 +90,11 @@ class CandidateArchiveNew:
             for i in candidate_indices
         ]
 
-        print(fidelities)
-
         if isinstance(fidelity, str):
             return np.array([
                 fid.get(fidelity, np.nan)
                 for fid in fidelities
-            ]).reshape(-1, 1)
+            ])
 
         elif fidelity:
             return np.array([

--- a/multiLevelCoSurrogates/CandidateArchiveNew.py
+++ b/multiLevelCoSurrogates/CandidateArchiveNew.py
@@ -141,7 +141,10 @@ class CandidateArchiveNew:
 
     def as_doe(self):
         """Present the stored candidates as a bi-fidelity DoE"""
-        pass
+        return BiFidelityDoE(
+            self.getcandidates(fidelity='high').candidates,
+            self.getcandidates(fidelity='low').candidates,
+        )
 
 
     def count(self, fidelity: str=None):

--- a/multiLevelCoSurrogates/CandidateArchiveNew.py
+++ b/multiLevelCoSurrogates/CandidateArchiveNew.py
@@ -5,19 +5,14 @@
 CandidateArchiveNew.py: Reimplementation of CandidateArchive to include indices,
                         be nicer and easier.
 """
-from collections import namedtuple
 from dataclasses import dataclass
-from itertools import chain
 from typing import Iterable, Union
-
-from more_itertools import pairwise
 
 __author__ = 'Sander van Rijn'
 __email__ = 's.j.van.rijn@liacs.leidenuniv.nl'
 
 
 import numpy as np
-from warnings import warn
 
 import mf2
 from multiLevelCoSurrogates.utils import BiFidelityDoE
@@ -159,14 +154,6 @@ class CandidateArchiveNew:
         )
 
 
-    def _addnewcandidate(self, *args, **kwargs):
-        pass
-
-
-    def _updatecandidate(self, *args, **kwargs):
-        pass
-
-
     def _updateminmax(self, value: float, fidelity: str=None):
 
         if fidelity not in self.max:  # or self.min
@@ -179,10 +166,6 @@ class CandidateArchiveNew:
 
     def __len__(self):
         return len(self.candidates)
-
-
-    def __index__(self, val):
-        pass
 
 
 @dataclass(eq=False)

--- a/multiLevelCoSurrogates/CandidateArchiveNew.py
+++ b/multiLevelCoSurrogates/CandidateArchiveNew.py
@@ -77,42 +77,26 @@ class CandidateArchiveNew:
             self.candidates.append(Candidate(new_idx, candidate, fidelities))
 
 
-    def getfitnesses(self, candidates: Iterable, fidelity: Union[str, Iterable[str]]=None) -> Iterable:
+    def getfitnesses(self, candidates: Iterable, fidelity: Union[str, Iterable[str]]) -> Iterable:
         """Return the relevant fitness values for the given candidates"""
+
+        if isinstance(fidelity, str):
+            fidelity = [fidelity]
 
         # retrieve all candidates by index, fails if candidate is not in archive
         candidate_indices = [
             self.candidates.index(candidate)
             for candidate in candidates
         ]
-        fidelities = [
-            self.candidates[i].fidelities
+
+        fitnesses = np.array([
+            [self.candidates[i].fidelities.get(f, np.nan) for f in fidelity]
             for i in candidate_indices
-        ]
+        ])
 
-        if isinstance(fidelity, str):
-            return np.array([
-                fid.get(fidelity, np.nan)
-                for fid in fidelities
-            ])
-
-        elif fidelity:
-            return np.array([
-                [fid.get(f, np.nan) for f in fidelity]
-                for fid in fidelities
-            ])
-
-        else:
-            # can probably be cached upon adding candidates...
-            all_fidelities = set()
-            for fid in fidelities:
-                all_fidelities.update(fid.keys())
-            all_fidelities = list(all_fidelities)
-
-            return np.array([
-                [fid.get(f, np.nan) for f in all_fidelities]
-                for fid in fidelities
-            ])
+        if len(fidelity) == 1:
+            return fitnesses.reshape(-1)
+        return fitnesses
 
 
     def getcandidates(self, *args, **kwargs):

--- a/multiLevelCoSurrogates/CandidateArchiveNew.py
+++ b/multiLevelCoSurrogates/CandidateArchiveNew.py
@@ -32,6 +32,9 @@ class CandidateArchiveNew:
         self._update_history = []
         self._all_fidelities = {}  # dictionary keys used as 'ordered set'
 
+        self.min = {}
+        self.max = {}
+
 
     @classmethod
     def from_multi_fidelity_function(
@@ -90,6 +93,7 @@ class CandidateArchiveNew:
 
         # create key entry if it does not yet exist
         self._all_fidelities[fidelity] = None
+        self._updateminmax(fitness, fidelity)
 
 
     def getfitnesses(self, candidates: Iterable, fidelity: Union[str, Iterable[str]]) -> Iterable:
@@ -164,15 +168,13 @@ class CandidateArchiveNew:
 
 
     def _updateminmax(self, value: float, fidelity: str=None):
-        # if value > self.max[fidelity]:
-        #     self.max[fidelity] = value
-        # elif value < self.min[fidelity]:
-        #     self.min[fidelity] = value
-        pass
 
-
-    def __contains__(self, val):
-        pass
+        if fidelity not in self.max:  # or self.min
+            self.max[fidelity] = self.min[fidelity] = value
+        elif value > self.max[fidelity]:
+            self.max[fidelity] = value
+        elif value < self.min[fidelity]:
+            self.min[fidelity] = value
 
 
     def __len__(self):

--- a/multiLevelCoSurrogates/__init__.py
+++ b/multiLevelCoSurrogates/__init__.py
@@ -10,7 +10,7 @@ __email__ = 's.j.van.rijn@liacs.leidenuniv.nl'
 
 
 from .CandidateArchive import *
-from .CandidateArchiveNew import *
+from .candidate_archive_new import *
 from .surrogates import *
 from .utils import *
 from .instance import *

--- a/multiLevelCoSurrogates/__init__.py
+++ b/multiLevelCoSurrogates/__init__.py
@@ -10,6 +10,7 @@ __email__ = 's.j.van.rijn@liacs.leidenuniv.nl'
 
 
 from .CandidateArchive import *
+from .CandidateArchiveNew import *
 from .surrogates import *
 from .utils import *
 from .instance import *

--- a/multiLevelCoSurrogates/candidate_archive_new.py
+++ b/multiLevelCoSurrogates/candidate_archive_new.py
@@ -32,18 +32,13 @@ class CandidateArchiveNew:
 
 
     @classmethod
-    def from_multi_fidelity_function(
-            cls,
-            multi_fid_func: mf2.MultiFidelityFunction,
-            *args,
-            **kwargs
-    ):
-
+    def from_multi_fidelity_function(cls, multi_fid_func: mf2.MultiFidelityFunction):
         return cls()
 
 
     @classmethod
-    def from_bi_fid_DoE(cls, high_x, low_x, high_y, low_y):
+    def from_bi_fid_DoE(cls, high_x: np.ndarray, low_x: np.ndarray,
+                        high_y: Iterable[float], low_y: Iterable[float]):
         """Create a populated CandidateArchive from an existing bi-fidelity DoE
         (high_x, low_x) with corresponding fitness values (high_y, low_y)
         """
@@ -58,7 +53,8 @@ class CandidateArchiveNew:
         return self._all_fidelities.keys()
 
 
-    def addcandidates(self, candidates, fitnesses, fidelity=None):
+    def addcandidates(self, candidates: np.ndarray,
+                      fitnesses: Iterable[float], fidelity: str=None):
         """Add candidate, fitness pairs to the archive for given fidelity.
         Will overwrite fitness value if already present.
         """
@@ -66,7 +62,7 @@ class CandidateArchiveNew:
             self.addcandidate(candidate, fitness, fidelity)
 
 
-    def addcandidate(self, candidate, fitness, fidelity=None):
+    def addcandidate(self, candidate: np.ndarray, fitness: float, fidelity: str=None):
         """Add a candidate, fitness pair to the archive for given fidelity.
         Will overwrite fitness value if already present
         """
@@ -91,7 +87,8 @@ class CandidateArchiveNew:
         self._updateminmax(fitness, fidelity)
 
 
-    def getfitnesses(self, candidates: Iterable, fidelity: Union[str, Iterable[str]]) -> Iterable:
+    def getfitnesses(self, candidates: np.ndarray,
+                     fidelity: Union[str, Iterable[str]]) -> np.ndarray:
         """Return the relevant fitness values for the given candidates"""
 
         if isinstance(fidelity, str):
@@ -113,7 +110,7 @@ class CandidateArchiveNew:
         return fitnesses
 
 
-    def getcandidates(self, fidelity=None):
+    def getcandidates(self, fidelity: Union[str, Iterable[str]]=None) -> CandidateSet:
         """Retrieve candidates and fitnesses from the archive.
         :fidelity:  (List of) fidelities to select by. Default: all
         :return:    Candidates, Fitnesses (tuple of numpy arrays)
@@ -138,7 +135,7 @@ class CandidateArchiveNew:
         return CandidateSet(np.array(candidates), np.array(fitnesses))
 
 
-    def as_doe(self):
+    def as_doe(self) -> BiFidelityDoE:
         """Present the stored candidates as a bi-fidelity DoE"""
         return BiFidelityDoE(
             self.getcandidates(fidelity='high').candidates,
@@ -146,7 +143,7 @@ class CandidateArchiveNew:
         )
 
 
-    def count(self, fidelity: str=None):
+    def count(self, fidelity: str=None) -> int:
         """Count the number of samples archived for the given fidelity"""
         return sum(
             fidelity in candidate.fidelities

--- a/multiLevelCoSurrogates/candidate_archive_new.py
+++ b/multiLevelCoSurrogates/candidate_archive_new.py
@@ -22,7 +22,7 @@ from .CandidateArchive import CandidateSet
 class CandidateArchiveNew:
 
     def __init__(self, *args, **kwargs):
-        """Archive of candidates that record fitnessin multiple fidelities"""
+        """Archive of candidates that record fitness in multiple fidelities"""
         self.candidates = []
         self._update_history = []
         self._all_fidelities = {}  # dictionary keys used as 'ordered set'

--- a/multiLevelCoSurrogates/candidate_archive_new.py
+++ b/multiLevelCoSurrogates/candidate_archive_new.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 """
-CandidateArchiveNew.py: Reimplementation of CandidateArchive to include indices,
-                        be nicer and easier.
+candidate_archive_new.py: Reimplementation of CandidateArchive to include indices,
+                          be nicer and easier.
 """
 from dataclasses import dataclass
 from typing import Iterable, Union

--- a/multiLevelCoSurrogates/candidate_archive_new.py
+++ b/multiLevelCoSurrogates/candidate_archive_new.py
@@ -37,10 +37,11 @@ class CandidateArchiveNew:
 
 
     @classmethod
-    def from_bi_fid_DoE(cls, high_x: np.ndarray, low_x: np.ndarray,
+    def from_bi_fid_doe(cls, high_x: np.ndarray, low_x: np.ndarray,
                         high_y: Iterable[float], low_y: Iterable[float]):
-        """Create a populated CandidateArchive from an existing bi-fidelity DoE
-        (high_x, low_x) with corresponding fitness values (high_y, low_y)
+        """Create a populated CandidateArchive from an existing bi-fidelity
+        Design of Experiments (DoE) [high_x, low_x] with corresponding fitness
+        values [high_y, low_y]
         """
         archive = cls()
         archive.addcandidates(low_x, low_y, fidelity='low')

--- a/multiLevelCoSurrogates/multiFidBO.py
+++ b/multiLevelCoSurrogates/multiFidBO.py
@@ -34,7 +34,7 @@ class MultiFidelityBO:
         self.show_plot = show_plot
         self.save_plot = save_plot
         self.func = multi_fid_func
-        self.ndim = archive.ndim if archive else self.func.ndim
+        self.ndim = self.func.ndim
         if len(self.func.u_bound) == self.ndim:
             self.bounds = self.func.bounds
         elif len(self.func.u_bound) == 1:
@@ -137,7 +137,7 @@ class MultiFidelityBO:
         if archive is not None:
             return archive
 
-        archive = CandidateArchive.from_multi_fidelity_function(self.func, ndim=self.ndim)
+        archive = CandidateArchive.from_multi_fidelity_function(self.func)
 
         samples = create_random_sample_set(self.ndim, zip(self.fidelities, [5, 8, 13]),
                                            desired_range=self.input_range)

--- a/multiLevelCoSurrogates/protoEG.py
+++ b/multiLevelCoSurrogates/protoEG.py
@@ -77,7 +77,7 @@ class ProtoEG:
             self.archive, num_reps=self.num_reps, step=self.interval
         )
 
-        full_DoE = self.archive.as_doe()
+        full_doe = self.archive.as_doe()
         X = X.reshape(1, -1)
 
         for h, l in instance_spec.pixels:
@@ -91,7 +91,7 @@ class ProtoEG:
 
             for idx in indices_to_resample:
                 mlcs.set_seed_by_instance(h, l, idx)
-                train_doe, test_doe = mlcs.split_with_include(full_DoE, h, l, must_include=X, fidelity=fidelity)
+                train_doe, test_doe = mlcs.split_with_include(full_doe, h, l, must_include=X, fidelity=fidelity)
                 test_high = test_doe.high
 
                 self.test_sets[(h,l)][idx] = test_high
@@ -134,7 +134,7 @@ class ProtoEG:
     def _create_train_archive(self, train):
         train_low_y = self.archive.getfitnesses(train.low, fidelity='low')
         train_high_y = self.archive.getfitnesses(train.high, fidelity='high')
-        return mlcs.CandidateArchive.from_bi_fid_DoE(train.high, train.low, train_high_y, train_low_y)
+        return mlcs.CandidateArchive.from_bi_fid_doe(train.high, train.low, train_high_y, train_low_y)
 
 
     def _extend_error_grid(self, fidelity: str, coord: Tuple[int, int]):

--- a/multiLevelCoSurrogates/utils/sampling.py
+++ b/multiLevelCoSurrogates/utils/sampling.py
@@ -43,13 +43,13 @@ def bi_fidelity_doe(ndim: int, num_high: int, num_low: int) -> BiFidelityDoE:
     return BiFidelityDoE(high_x, low_x)
 
 
-def remove_from_bi_fid_doe(X, DoE: BiFidelityDoE):
+def remove_from_bi_fid_doe(X, doe: BiFidelityDoE):
     """Remove given x from both fidelities of the given DoE"""
     if len(np.array(X).shape) > 1:
         raise NotImplementedError('remove_from_bi_fid_doe only implemented for 1D arrays.')
     X = tuple(X)
-    high = np.array([x for x in DoE.high if tuple(x) != X])
-    low = np.array([x for x in DoE.low if tuple(x) != X])
+    high = np.array([x for x in doe.high if tuple(x) != X])
+    low = np.array([x for x in doe.low if tuple(x) != X])
     return BiFidelityDoE(high, low)
 
 
@@ -64,7 +64,7 @@ class NoSpareLowFidSamplesWarning(UserWarning):
     """Warns while splitting DoE when only high-fidelity samples are selected for low-fidelity"""
 
 
-def split_bi_fidelity_doe(DoE: BiFidelityDoE, num_high: int, num_low: int) -> Tuple[BiFidelityDoE, BiFidelityDoE]:
+def split_bi_fidelity_doe(doe: BiFidelityDoE, num_high: int, num_low: int) -> Tuple[BiFidelityDoE, BiFidelityDoE]:
     """Given an existing bi-fidelity Design of Experiments (DoE) `high, low`,
     creates a subselection of given size `num_high, num_low` based on uniform
     selection. The subselection maintains the property that all high-fidelity
@@ -72,14 +72,14 @@ def split_bi_fidelity_doe(DoE: BiFidelityDoE, num_high: int, num_low: int) -> Tu
 
     Raises a `ValueError` if invalid `num_high` or `num_low` are given.
     """
-    high = [tuple(x) for x in DoE.high]
-    low = [tuple(x) for x in DoE.low]
+    high = [tuple(x) for x in doe.high]
+    low = [tuple(x) for x in doe.low]
 
     # Errors
     if not 0 <= num_high <= len(high):
-        raise ValueError(f"'num_high' must be in the range [0, len(DoE.high) (={len(DoE.high)})], but is {num_high}")
+        raise ValueError(f"'num_high' must be in the range [0, len(doe.high) (={len(doe.high)})], but is {num_high}")
     if num_low > len(low):
-        raise ValueError(f"'num_low' cannot be greater than len(DoE.low) (={len(DoE.low)}), but is {num_low}")
+        raise ValueError(f"'num_low' cannot be greater than len(doe.low) (={len(doe.low)}), but is {num_low}")
     if num_low < num_high:
         raise ValueError(f"'num_low' must be at least 'num_high', but {num_low} < {num_high}")
 
@@ -128,7 +128,7 @@ def split_bi_fidelity_doe(DoE: BiFidelityDoE, num_high: int, num_low: int) -> Tu
     return selected, left_out
 
 
-def split_with_include(DoE: BiFidelityDoE, num_high: int, num_low: int,
+def split_with_include(doe: BiFidelityDoE, num_high: int, num_low: int,
                        must_include, fidelity: str='high') -> Tuple[BiFidelityDoE, BiFidelityDoE]:
     """Given an existing bi-fidelity Design of Experiments (DoE) `high, low`,
     creates a subselection of given size `num_high, num_low` based on uniform
@@ -136,18 +136,18 @@ def split_with_include(DoE: BiFidelityDoE, num_high: int, num_low: int,
     samples are a subset of the low-fidelity samples.
 
     Raises a `ValueError` if invalid `num_high` or `num_low` are given.
-    :param DoE:          Original bi-fidelity DoE to split
+    :param doe:          Original bi-fidelity DoE to split
     :param num_high:     Number of candidates to select for high-fidelity
     :param num_low:      Number of candidates to select for low-fidelity
     :param must_include: Additional candidate(s) to explicitly include in `selected`.
                          Must be an array of shape (num_candidates, ndim) of candidates
-                         not already present in `DoE`
+                         not already present in `doe`
     :param fidelity:     Which fidelity the 'must_include' candidates should be added as
     """
     if fidelity not in ['high', 'low']:
         raise ValueError(f"Invalid fidelity '{fidelity}', should be 'high' or 'low'")
 
-    DoE = remove_from_bi_fid_doe(must_include.flatten(), DoE)
+    doe = remove_from_bi_fid_doe(must_include.flatten(), doe)
 
     num_low -= 1
     if fidelity == 'high':
@@ -155,7 +155,7 @@ def split_with_include(DoE: BiFidelityDoE, num_high: int, num_low: int,
 
     with catch_warnings():
         simplefilter("ignore", category=NoSpareLowFidSamplesWarning)
-        selected, other = split_bi_fidelity_doe(DoE, num_high, num_low)
+        selected, other = split_bi_fidelity_doe(doe, num_high, num_low)
 
     low = np.concatenate([selected.low, must_include])
     high = np.concatenate([selected.high, must_include]) if fidelity == 'high' else selected.high

--- a/notebooks/forrester2007/function_defs.py
+++ b/notebooks/forrester2007/function_defs.py
@@ -47,7 +47,7 @@ def create_mse_tracking(func, sample_generator,
         low_x = sample_generator(ndim, num_low)
         high_x = low_x[np.random.choice(num_low, num_high, replace=False)]
 
-        archive = mlcs.CandidateArchive(ndim=ndim, fidelities=['high', 'low', 'high-low'])
+        archive = mlcs.CandidateArchive(fidelities=['high', 'low', 'high-low'])
         archive.addcandidates(low_x, func.low(low_x), fidelity='low')
         archive.addcandidates(high_x, func.high(high_x), fidelity='high')
 
@@ -138,7 +138,7 @@ blue_circle = {'marker': 'o', 'facecolors': 'none', 'color': 'blue'}
 
 
 def create_models_and_compare(func, low, high, steps=None, save_as=None):
-    archive = mlcs.CandidateArchive(ndim=2, fidelities=['high', 'low', 'high-low'])
+    archive = mlcs.CandidateArchive(fidelities=['high', 'low', 'high-low'])
     archive.addcandidates(low, func.low(low), fidelity='low')
     archive.addcandidates(high, func.high(high), fidelity='high')
 

--- a/scripts/experiments/2020-11-05-simple-mfbo.py
+++ b/scripts/experiments/2020-11-05-simple-mfbo.py
@@ -427,7 +427,7 @@ def make_mf_doe(func: mf2.MultiFidelityFunction, doe_n_high: int, doe_n_low: int
     high_x, low_x = scale_to_function(func, [high_x, low_x])
     high_y, low_y = func.high(high_x), func.low(low_x)
     # create archive
-    return mlcs.CandidateArchive.from_bi_fid_DoE(high_x, low_x, high_y, low_y)
+    return mlcs.CandidateArchive.from_bi_fid_doe(high_x, low_x, high_y, low_y)
 
 
 #TODO de-duplicate (already present in processing.py

--- a/scripts/experiments/2021-07-06-manual-additions.py
+++ b/scripts/experiments/2021-07-06-manual-additions.py
@@ -66,7 +66,7 @@ def proto_EG_multifid_bo(func, init_budget, cost_ratio, doe_n_high, doe_n_low, f
     budget = init_budget - (doe_n_high + doe_n_low*cost_ratio)
 
     #create archive
-    archive = mlcs.CandidateArchive.from_bi_fid_DoE(high_x, low_x, high_y, low_y)
+    archive = mlcs.CandidateArchive.from_bi_fid_doe(high_x, low_x, high_y, low_y)
 
     proto_eg = mlcs.ProtoEG(archive, num_reps=num_reps, mfm_opts=mfm_opts)
     proto_eg.subsample_errorgrid()
@@ -164,7 +164,7 @@ def simple_multifid_bo(func, budget, cost_ratio, doe_n_high, doe_n_low, fidelity
     budget -= (doe_n_high + doe_n_low*cost_ratio)
 
     #create archive
-    archive = mlcs.CandidateArchive.from_bi_fid_DoE(high_x, low_x, high_y, low_y)
+    archive = mlcs.CandidateArchive.from_bi_fid_doe(high_x, low_x, high_y, low_y)
 
     #make mf-model using archive
     mfbo = mlcs.MultiFidelityBO(func, archive, **mfm_opts)

--- a/scripts/experiments/experiments.py
+++ b/scripts/experiments/experiments.py
@@ -148,7 +148,7 @@ def plot_model_and_samples(func: MultiFidelityFunction, kernel: str,
     high_y, low_y = func.high(high_x), \
                     func.low(low_x)
 
-    archive = mlcs.CandidateArchive.from_multi_fidelity_function(func, ndim=func.ndim)
+    archive = mlcs.CandidateArchive.from_multi_fidelity_function(func)
     archive.addcandidates(low_x, low_y, fidelity='low')
     archive.addcandidates(high_x, high_y, fidelity='high')
 
@@ -254,7 +254,7 @@ def create_model_error_grid(
                         func.low(low_x)
 
         # Create an archive from the MF-function and MF-DoE data
-        archive = mlcs.CandidateArchive.from_multi_fidelity_function(func, ndim=func.ndim)
+        archive = mlcs.CandidateArchive.from_multi_fidelity_function(func)
         archive.addcandidates(low_x, low_y, fidelity='low')
         archive.addcandidates(high_x, high_y, fidelity='high')
 
@@ -378,7 +378,7 @@ def create_resampling_error_grid(
                         func.low(low_x)
 
         # Create an archive from the MF-function and MF-DoE data
-        archive = mlcs.CandidateArchive.from_multi_fidelity_function(func, ndim=func.ndim)
+        archive = mlcs.CandidateArchive.from_multi_fidelity_function(func)
         archive.addcandidates(low_x, low_y, fidelity='low')
         archive.addcandidates(high_x, high_y, fidelity='high')
 
@@ -492,7 +492,7 @@ def create_resampling_leftover_error_grid(
                         func.low(selected.low)
 
         # Create an archive from the MF-function and MF-DoE data
-        archive = mlcs.CandidateArchive.from_multi_fidelity_function(func, ndim=func.ndim)
+        archive = mlcs.CandidateArchive.from_multi_fidelity_function(func)
         archive.addcandidates(selected.low, low_y, fidelity='low')
         archive.addcandidates(selected.high, high_y, fidelity='high')
 
@@ -668,12 +668,9 @@ def create_subsampling_error_grid(
         # but that values from `archive` are re-used.
         raise NotImplementedError
 
-    highs = archive.getcandidates(fidelity='high').candidates
-    lows = archive.getcandidates(fidelity='low').candidates
-    DoE = BiFidelityDoE(highs, lows)
-
-    max_num_high = len(highs)
-    max_num_low = len(lows)
+    DoE = archive.as_doe()
+    max_num_high = len(DoE.high)
+    max_num_low = len(DoE.low)
 
     error_grid = np.full((max_num_high+1, max_num_low+1, num_reps+1, 3), np.nan)
 
@@ -696,7 +693,7 @@ def create_subsampling_error_grid(
                         func.low(low_x)
 
         # Create an archive from the MF-function and MF-DoE data
-        arch = mlcs.CandidateArchive.from_multi_fidelity_function(func, ndim=func.ndim)
+        arch = mlcs.CandidateArchive.from_multi_fidelity_function(func)
         arch.addcandidates(low_x, low_y, fidelity='low')
         arch.addcandidates(high_x, high_y, fidelity='high')
 

--- a/scripts/experiments/experiments.py
+++ b/scripts/experiments/experiments.py
@@ -316,7 +316,7 @@ def plot_1d_example(func, high_x, high_y, low_x, low_y, mfbo, num_high, num_low,
 
 def create_resampling_error_grid(
         func: MultiFidelityFunction,
-        DoE_spec: Tuple[int, int],
+        doe_spec: Tuple[int, int],
         instances: Sequence[Instance],
         mfbo_options: Dict[str, Any],
         save_dir: Path,
@@ -335,7 +335,7 @@ def create_resampling_error_grid(
 
     # Determine unique output path for this experiment
     surr_name = repr_surrogate_name(mfbo_options)
-    doe_high, doe_low = DoE_spec
+    doe_high, doe_low = doe_spec
 
     fname = standardize_fname_for_file(func.name)
     output_path = save_dir / f"{surr_name}-{func.ndim}d-{fname}-sub{doe_high}-{doe_low}.nc"
@@ -360,8 +360,8 @@ def create_resampling_error_grid(
 
     # Create initial DoE
     np.random.seed(20160501)  # Setting seed for reproducibility
-    DoE = mlcs.bi_fidelity_doe(func.ndim, doe_high, doe_low)
-    DoE = scale_to_function(func, DoE)
+    doe = mlcs.bi_fidelity_doe(func.ndim, doe_high, doe_low)
+    doe = scale_to_function(func, doe)
 
 
     results = []
@@ -373,7 +373,7 @@ def create_resampling_error_grid(
         set_seed_by_instance(num_high, num_low, rep)
 
         # Create sub-sampled Multi-Fidelity DoE in- and output according to instance specification
-        (high_x, low_x), _ = mlcs.split_bi_fidelity_doe(DoE, num_high, num_low)
+        (high_x, low_x), _ = mlcs.split_bi_fidelity_doe(doe, num_high, num_low)
         high_y, low_y = func.high(high_x), \
                         func.low(low_x)
 
@@ -429,7 +429,7 @@ def create_resampling_error_grid(
 
 def create_resampling_leftover_error_grid(
         func: MultiFidelityFunction,
-        DoE_spec: Tuple[int, int],
+        doe_spec: Tuple[int, int],
         instances: Sequence[Instance],
         mfbo_options: Dict[str, Any],
         save_dir: Path,
@@ -449,7 +449,7 @@ def create_resampling_leftover_error_grid(
 
     # Determine unique output path for this experiment
     surr_name = repr_surrogate_name(mfbo_options)
-    doe_high, doe_low = DoE_spec
+    doe_high, doe_low = doe_spec
 
     fname = standardize_fname_for_file(func.name)
     output_path = save_dir / f"{surr_name}-{func.ndim}d-{fname}-sub{doe_high}-{doe_low}-seed{seed_offset}.nc"
@@ -474,8 +474,8 @@ def create_resampling_leftover_error_grid(
 
     # Create initial DoE
     np.random.seed(20160501 + seed_offset)  # Setting seed for reproducibility
-    DoE = mlcs.bi_fidelity_doe(func.ndim, doe_high, doe_low)
-    DoE = scale_to_function(func, DoE)
+    doe = mlcs.bi_fidelity_doe(func.ndim, doe_high, doe_low)
+    doe = scale_to_function(func, doe)
 
 
     results = []
@@ -487,7 +487,7 @@ def create_resampling_leftover_error_grid(
         set_seed_by_instance(num_high, num_low, rep)
 
         # Create sub-sampled Multi-Fidelity DoE in- and output according to instance specification
-        selected, test = mlcs.split_bi_fidelity_doe(DoE, num_high, num_low)
+        selected, test = mlcs.split_bi_fidelity_doe(doe, num_high, num_low)
         high_y, low_y = func.high(selected.high), \
                         func.low(selected.low)
 
@@ -668,9 +668,9 @@ def create_subsampling_error_grid(
         # but that values from `archive` are re-used.
         raise NotImplementedError
 
-    DoE = archive.as_doe()
-    max_num_high = len(DoE.high)
-    max_num_low = len(DoE.low)
+    doe = archive.as_doe()
+    max_num_high = len(doe.high)
+    max_num_low = len(doe.low)
 
     error_grid = np.full((max_num_high+1, max_num_low+1, num_reps+1, 3), np.nan)
 
@@ -688,7 +688,7 @@ def create_subsampling_error_grid(
             print(f"{i}/{len(instances)}")
 
         # Create sub-sampled Multi-Fidelity DoE in- and output according to instance specification
-        (high_x, low_x), _ = mlcs.split_bi_fidelity_doe(DoE, num_high, num_low)
+        (high_x, low_x), _ = mlcs.split_bi_fidelity_doe(doe, num_high, num_low)
         high_y, low_y = func.high(high_x), \
                         func.low(low_x)
 

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -31,6 +31,15 @@ def test_bare_archive(Archive):
     assert len(archive) == 0
 
 
+@pytest.mark.parametrize('Archive', implementations)
+def test_add_candidate_increases_length(Archive):
+    archive = Archive()
+    old_length = len(archive)
+
+    archive.addcandidate(np.random.rand(2), np.random.random())
+    assert len(archive) == old_length + 1
+
+
 ### A 'happy path' is a simple run through some functionality that just works
 
 @pytest.mark.parametrize('Archive', implementations)
@@ -41,7 +50,6 @@ def test_1fid_happy_path(Archive):
     archive.addcandidates(candidates.tolist(), fitnesses)
 
     result = archive.getcandidates()
-    assert isinstance(result, mlcs.CandidateSet)
     assert hasattr(result, 'candidates')
     assert hasattr(result, 'fitnesses')
 

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -70,6 +70,15 @@ def test_add_same_candidate_maintains_length(Archive):
     assert len(archive) == old_length
 
 
+@pytest.mark.parametrize('Archive', implementations)
+def test_from_bifiddoe(Archive):
+    ndim, num_high, num_low = 2, 5, 10
+    doe = mlcs.bi_fidelity_doe(ndim, num_high, num_low)
+
+    archive = Archive.from_bi_fid_DoE(*doe, np.random.rand(num_high), np.random.rand(num_low))
+    assert len(archive) == num_low
+
+
 ### A 'happy path' is a simple run through some functionality that just works
 
 @pytest.mark.parametrize('Archive', implementations)

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -125,11 +125,6 @@ def test_getfitnesses_multiple_fid(Archive):
             assert np.count_nonzero(~np.isnan(column)) == len(data[fidelity][1])
 
 
-# @pytest.mark.parametrize('Archive', implementations)
-# def test_getfitnesses_no_fid(Archive):
-#     pass
-
-
 ### A 'happy path' is a simple run through some functionality that just works
 
 @pytest.mark.parametrize('Archive', implementations)

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -95,13 +95,15 @@ def test_getfitnesses_one_fid(Archive):
     for fidelity, (candidates, fitness) in data.items():
         archive.addcandidates(candidates, fitness, fidelity=fidelity)
 
-    for fidelity, fitness in data.items():
-        stored_fitness = archive.getfitnesses(data[fidelity][0], fidelity=fidelity)
-        assert np.allclose(stored_fitness, data[fidelity][1])
+    # retrieve exactly the fitnesses that were input for these candidates
+    for fidelity, (candidates, fitness) in data.items():
+        stored_fitness = archive.getfitnesses(candidates, fidelity=fidelity)
+        assert np.allclose(stored_fitness, fitness)
 
-    for fidelity in data.keys():
+    # retrieve this fitness for all candidates, assert #input are not NaN
+    for fidelity, (_, fitness) in data.items():
         stored_fitness = archive.getfitnesses(all_candidates, fidelity=fidelity)
-        assert np.count_nonzero(np.isnan(stored_fitness)) == len(data[fidelity][1])
+        assert np.count_nonzero(~np.isnan(stored_fitness)) == len(fitness)
 
 
 # @pytest.mark.parametrize('Archive', implementations)

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -110,7 +110,7 @@ def test_from_bifiddoe(Archive):
     ndim, num_high, num_low = 2, 5, 10
     doe = mlcs.bi_fidelity_doe(ndim, num_high, num_low)
 
-    archive = Archive.from_bi_fid_DoE(*doe, np.random.rand(num_high), np.random.rand(num_low))
+    archive = Archive.from_bi_fid_doe(*doe, np.random.rand(num_high), np.random.rand(num_low))
     assert len(archive) == num_low
     assert archive.count('high') == num_high
     assert archive.count('low') == num_low

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -85,6 +85,19 @@ def test_add_same_candidate_maintains_length(Archive):
 
 
 @pytest.mark.parametrize('Archive', implementations)
+def test_add_candidate_without_fidelity_raises_error(Archive):
+    all_candidates, archive, data = setup_archive(Archive)
+
+    candidates = np.random.rand(5, 2)
+    fitnesses = np.random.rand(5, 1)
+
+    with pytest.raises(ValueError):
+        archive.addcandidate(candidates[0], fitnesses[0])
+    with pytest.raises(ValueError):
+        archive.addcandidates(candidates, fitnesses)
+
+
+@pytest.mark.parametrize('Archive', implementations)
 def test_from_bifiddoe(Archive):
     ndim, num_high, num_low = 2, 5, 10
     doe = mlcs.bi_fidelity_doe(ndim, num_high, num_low)

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -121,8 +121,8 @@ def test_getfitnesses_one_fid(Archive):
 @pytest.mark.parametrize('Archive', implementations)
 def test_1fid_happy_path(Archive):
     archive = Archive()
-    candidates = np.random.randn(30).reshape((10, 3))
-    fitnesses = np.random.randn(10).reshape((10, 1))
+    candidates = np.random.rand(10, 3)
+    fitnesses = np.random.rand(10, 1)
     archive.addcandidates(candidates.tolist(), fitnesses)
 
     result = archive.getcandidates()
@@ -140,8 +140,8 @@ def test_2fid_happy_path(Archive):
     archive = Archive(fidelities=['AAA', 'BBB'])
 
     num_candidates = 10
-    candidates = np.random.randn(num_candidates*ndim).reshape((num_candidates, ndim))
-    fitnesses = np.random.randn(num_candidates).reshape((num_candidates, 1))
+    candidates = np.random.rand(num_candidates, ndim)
+    fitnesses = np.random.rand(num_candidates, 1)
     with pytest.raises(ValueError):
         archive.addcandidates(candidates, fitnesses)
 
@@ -154,7 +154,7 @@ def test_2fid_happy_path(Archive):
     np.testing.assert_array_almost_equal(fitnesses, fit)
 
     num_fitnesses_BBB = 5
-    new_fitnesses = np.random.randn(num_fitnesses_BBB).reshape((num_fitnesses_BBB, 1))
+    new_fitnesses = np.random.rand(num_fitnesses_BBB, 1)
     indices = np.random.choice(np.arange(10), num_fitnesses_BBB, replace=False)
 
     archive.addcandidates(candidates[indices].tolist(), new_fitnesses, fidelity='BBB')

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -81,6 +81,39 @@ def test_from_bifiddoe(Archive):
     assert archive.count('low') == num_low
 
 
+@pytest.mark.parametrize('Archive', implementations)
+def test_getfitnesses_one_fid(Archive):
+    archive = Archive(fidelities=['A', 'B', 'C'])
+
+    all_candidates = np.random.rand(10, 2)
+
+    data = {
+        'A': (all_candidates[:5], np.random.rand(5)),
+        'B': (all_candidates, np.random.rand(10)),
+        'C': (all_candidates[5:], np.random.rand(5)),
+    }
+    for fidelity, (candidates, fitness) in data.items():
+        archive.addcandidates(candidates, fitness, fidelity=fidelity)
+
+    for fidelity, fitness in data.items():
+        stored_fitness = archive.getfitnesses(data[fidelity][0], fidelity=fidelity)
+        assert np.allclose(stored_fitness, data[fidelity][1])
+
+    for fidelity in data.keys():
+        stored_fitness = archive.getfitnesses(all_candidates, fidelity=fidelity)
+        assert np.count_nonzero(np.isnan(stored_fitness)) == len(data[fidelity][1])
+
+
+# @pytest.mark.parametrize('Archive', implementations)
+# def test_getfitnesses_multiple_fid(Archive):
+#     pass
+#
+#
+# @pytest.mark.parametrize('Archive', implementations)
+# def test_getfitnesses_no_fid(Archive):
+#     pass
+
+
 ### A 'happy path' is a simple run through some functionality that just works
 
 @pytest.mark.parametrize('Archive', implementations)

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -40,6 +40,22 @@ def test_add_candidate_increases_length(Archive):
     assert len(archive) == old_length + 1
 
 
+@pytest.mark.parametrize('Archive', implementations)
+def test_add_same_candidate_maintains_length(Archive):
+    archive = Archive()
+    candidate, fitness = np.random.rand(2), np.random.random()
+    archive.addcandidate(candidate, fitness)
+    old_length = len(archive)
+
+    # adding exact same candidate does not change length
+    archive.addcandidate(candidate, fitness)
+    assert len(archive) == old_length
+
+    # adding same candidate with different fitness does not change length
+    archive.addcandidate(candidate, np.random.random())
+    assert len(archive) == old_length
+
+
 ### A 'happy path' is a simple run through some functionality that just works
 
 @pytest.mark.parametrize('Archive', implementations)

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -41,6 +41,20 @@ def test_add_candidate_increases_length(Archive):
 
 
 @pytest.mark.parametrize('Archive', implementations)
+def test_add_candidates_increases_length(Archive):
+    archive1 = Archive()
+    archive2 = Archive()
+    num_candidates = 5
+
+    for _ in range(num_candidates):
+        archive1.addcandidate(np.random.rand(2), np.random.random())
+
+    archive2.addcandidates(np.random.rand(5, 2), np.random.rand(5))
+
+    assert len(archive1) == len(archive2) == num_candidates
+
+
+@pytest.mark.parametrize('Archive', implementations)
 def test_add_same_candidate_maintains_length(Archive):
     archive = Archive()
     candidate, fitness = np.random.rand(2), np.random.random()

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -84,6 +84,15 @@ def test_add_same_candidate_maintains_length(Archive):
 
 
 @pytest.mark.parametrize('Archive', implementations)
+def test_min_max(Archive):
+    all_candidates, archive, data = setup_archive(Archive)
+
+    for fidelity, (_, fitnesses) in data.items():
+        assert archive.max[fidelity] == np.max(fitnesses)
+        assert archive.min[fidelity] == np.min(fitnesses)
+
+
+@pytest.mark.parametrize('Archive', implementations)
 def test_add_candidate_without_fidelity_raises_error(Archive):
     all_candidates, archive, data = setup_archive(Archive)
 

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -21,6 +21,7 @@ from multiLevelCoSurrogates import CandidateArchive, CandidateArchiveNew
 
 implementations = [
     CandidateArchive,
+    CandidateArchiveNew,
 ]
 
 

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -138,10 +138,8 @@ def test_getfitnesses_multiple_fid(Archive):
             assert np.count_nonzero(~np.isnan(column)) == len(data[fidelity][1])
 
 
-### A 'happy path' is a simple run through some functionality that just works
-
 @pytest.mark.parametrize('Archive', implementations)
-def test_1fid_happy_path(Archive):
+def test_1fid_getcandidates(Archive):
     archive = Archive()
     candidates = np.random.rand(10, 3)
     fitnesses = np.random.rand(10, 1)
@@ -157,19 +155,14 @@ def test_1fid_happy_path(Archive):
 
 
 @pytest.mark.parametrize('Archive', implementations)
-def test_2fid_happy_path(Archive):
+def test_2fid_getcandidates(Archive):
     ndim = 3
     archive = Archive(fidelities=['AAA', 'BBB'])
 
     num_candidates = 10
     candidates = np.random.rand(num_candidates, ndim)
     fitnesses = np.random.rand(num_candidates, 1)
-    with pytest.raises(ValueError):
-        archive.addcandidates(candidates, fitnesses)
-
     archive.addcandidates(candidates.tolist(), fitnesses, fidelity='AAA')
-    assert archive.count('AAA') == num_candidates
-    assert archive.count('BBB') == 0
 
     cand, fit = archive.getcandidates(fidelity='AAA')
     np.testing.assert_array_almost_equal(candidates, cand)
@@ -180,8 +173,6 @@ def test_2fid_happy_path(Archive):
     indices = np.random.choice(np.arange(10), num_fitnesses_BBB, replace=False)
 
     archive.addcandidates(candidates[indices].tolist(), new_fitnesses, fidelity='BBB')
-    assert archive.count('AAA') == num_candidates
-    assert archive.count('BBB') == num_fitnesses_BBB
 
     cand, fit = archive.getcandidates(fidelity='BBB')
     # comparing sorted because order does not matter...

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -8,7 +8,6 @@ test_CandidateArchive.py: Set of tests for the mlcs.CandidateArchive
 __author__ = 'Sander van Rijn'
 __email__ = 's.j.van.rijn@liacs.leidenuniv.nl'
 
-from collections import namedtuple
 
 from hypothesis import given
 from hypothesis.strategies import lists, text, integers
@@ -106,6 +105,25 @@ def test_from_bifiddoe(Archive):
     assert len(archive) == num_low
     assert archive.count('high') == num_high
     assert archive.count('low') == num_low
+
+
+@pytest.mark.parametrize('Archive', implementations)
+def test_as_doe(Archive):
+    archive = Archive(fidelities=['high', 'low'])
+
+    high_x = np.random.rand(10, 2)
+    archive.addcandidates(high_x, np.random.rand(10), fidelity='high')
+
+    low_x = np.random.rand(20, 2)
+    archive.addcandidates(low_x, np.random.rand(20), fidelity='low')
+
+    doe = archive.as_doe()
+
+    assert hasattr(doe, 'high')
+    assert hasattr(doe, 'low')
+
+    np.testing.assert_array_almost_equal(doe.high, high_x)
+    np.testing.assert_array_almost_equal(doe.low, low_x)
 
 
 @pytest.mark.parametrize('Archive', implementations)

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -77,6 +77,8 @@ def test_from_bifiddoe(Archive):
 
     archive = Archive.from_bi_fid_DoE(*doe, np.random.rand(num_high), np.random.rand(num_low))
     assert len(archive) == num_low
+    assert archive.count('high') == num_high
+    assert archive.count('low') == num_low
 
 
 ### A 'happy path' is a simple run through some functionality that just works

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -20,7 +20,7 @@ from multiLevelCoSurrogates import CandidateArchive
 
 
 def test_bare_archive():
-    archive = CandidateArchive(ndim=0)
+    archive = CandidateArchive()
     assert archive.fidelities == ['fitness']
     assert len(archive) == len(archive.data) == 0
     assert len(archive.max) == len(archive.min) == len(archive.fidelities)
@@ -28,19 +28,19 @@ def test_bare_archive():
 
 def test_single_fidelity():
     fid = 'my_fidelity'
-    archive = CandidateArchive(ndim=0, fidelities=[fid])
+    archive = CandidateArchive(fidelities=[fid])
     assert archive.fidelities == [fid]
 
 
 def test_multiple_fidelities():
     fids = [f'my_{i}th_fidelity' for i in range(5)]
-    archive = CandidateArchive(ndim=0, fidelities=fids)
+    archive = CandidateArchive(fidelities=fids)
     assert archive.fidelities == fids
 
 
 def test_fidelity_not_specified():
     fids = [f'my_{i}th_fidelity' for i in range(5)]
-    archive = CandidateArchive(ndim=0, fidelities=fids)
+    archive = CandidateArchive(fidelities=fids)
     with pytest.raises(ValueError):
         archive.addcandidate([1, 2, 3], fitness=1)
 
@@ -56,18 +56,12 @@ def test_from_mff(fidelities, ndim):
     # Each of the n-1 consecutive pairs has to be added as a new fidelity,
     # so len(archive.fidelities) should be n + (n-1) = 2n - 1
     assert len(archive.fidelities) == 2*len(fidelities) - 1
-    assert archive.ndim == ndim
-
-    mff = MultiFidFunc(0.5, fidelities)
-    archive = CandidateArchive.from_multi_fidelity_function(mff, ndim=ndim)
-    # archive.ndim should not be the non-integer value of 0.5 when overwritten
-    assert archive.ndim == ndim
 
 
 ### A 'happy path' is a simple run through some functionality that just works
 
 def test_1fid_happy_path():
-    archive = CandidateArchive(ndim=3)
+    archive = CandidateArchive()
     candidates = np.random.randn(30).reshape((10, 3))
     fitnesses = np.random.randn(10).reshape((10, 1))
     archive.addcandidates(candidates.tolist(), fitnesses)
@@ -84,7 +78,7 @@ def test_1fid_happy_path():
 
 def test_2fid_happy_path():
     ndim = 3
-    archive = CandidateArchive(ndim=ndim, fidelities=['AAA', 'BBB'])
+    archive = CandidateArchive(fidelities=['AAA', 'BBB'])
 
     num_candidates = 10
     candidates = np.random.randn(num_candidates*ndim).reshape((num_candidates, ndim))

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -25,6 +25,19 @@ implementations = [
 ]
 
 
+def setup_archive(Archive):
+    archive = Archive(fidelities=['A', 'B', 'C'])
+    all_candidates = np.random.rand(10, 2)
+    data = {
+        'A': (all_candidates[:5], np.random.rand(5)),
+        'B': (all_candidates, np.random.rand(10)),
+        'C': (all_candidates[5:], np.random.rand(5)),
+    }
+    for fidelity, (candidates, fitness) in data.items():
+        archive.addcandidates(candidates, fitness, fidelity=fidelity)
+    return all_candidates, archive, data
+
+
 @pytest.mark.parametrize('Archive', implementations)
 def test_bare_archive(Archive):
     archive = Archive()
@@ -83,17 +96,7 @@ def test_from_bifiddoe(Archive):
 
 @pytest.mark.parametrize('Archive', implementations)
 def test_getfitnesses_one_fid(Archive):
-    archive = Archive(fidelities=['A', 'B', 'C'])
-
-    all_candidates = np.random.rand(10, 2)
-
-    data = {
-        'A': (all_candidates[:5], np.random.rand(5)),
-        'B': (all_candidates, np.random.rand(10)),
-        'C': (all_candidates[5:], np.random.rand(5)),
-    }
-    for fidelity, (candidates, fitness) in data.items():
-        archive.addcandidates(candidates, fitness, fidelity=fidelity)
+    all_candidates, archive, data = setup_archive(Archive)
 
     # retrieve exactly the fitnesses that were input for these candidates
     for fidelity, (candidates, fitness) in data.items():

--- a/tests/test_multi_fidelity_model.py
+++ b/tests/test_multi_fidelity_model.py
@@ -21,7 +21,7 @@ def test_simple_path():
 
     low_x = np.linspace(0,1,11).reshape(-1,1)
     high_x = low_x[[0,4,6,10]]
-    archive = mlcs.CandidateArchive(1, ['high', 'low', 'high-low'])
+    archive = mlcs.CandidateArchive(['high', 'low', 'high-low'])
     archive.addcandidates(low_x, mf2.forrester.low(low_x), fidelity='low')
     archive.addcandidates(high_x, mf2.forrester.high(high_x), fidelity='high')
     mfm = mlcs.MultiFidelityModel(mf2.forrester.fidelity_names, archive)

--- a/tests/test_protoEG.py
+++ b/tests/test_protoEG.py
@@ -39,7 +39,7 @@ def get_experiment_subsampled_EG(func, DoE, instances):
                                     func.low(train.low)
 
         # Create an archive from the MF-function and MF-DoE data
-        archive = mlcs.CandidateArchive.from_multi_fidelity_function(func, ndim=func.ndim)
+        archive = mlcs.CandidateArchive.from_multi_fidelity_function(func)
         archive.addcandidates(train.low, train_low_y, fidelity='low')
         archive.addcandidates(train.high, train_high_y, fidelity='high')
 
@@ -80,7 +80,7 @@ def valid_subsample_spec(draw):
 @given(valid_subsample_spec())
 def test_calc_reuse_fraction_high(spec):
     num_high, num_low, max_high, max_low = spec
-    peg = mlcs.ProtoEG(archive=mlcs.CandidateArchive(ndim=0))
+    peg = mlcs.ProtoEG(archive=mlcs.CandidateArchive())
 
     part1 = binom(max_high, num_high)
     part2 = binom(max_high + 1, num_high)
@@ -98,7 +98,7 @@ def test_calc_reuse_fraction_high(spec):
 @given(valid_subsample_spec())
 def test_calc_reuse_fraction_low(spec):
     num_high, num_low, max_high, max_low = spec
-    peg = mlcs.ProtoEG(archive=mlcs.CandidateArchive(ndim=0))
+    peg = mlcs.ProtoEG(archive=mlcs.CandidateArchive())
 
     part1 = binom(max_low - num_high, num_low - num_high)
     part2 = binom(max_low+1 - num_high, num_low - num_high)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -62,59 +62,59 @@ def test_must_include_no_warning():
 
 # remove_from_bi_fid_doe
 def test_remove_from_bifiddoe():
-    DoE = mlcs.bi_fidelity_doe(2, 5, 10)
-    X = DoE.high[3]
-    assert X in DoE.high and X in DoE.low
-    DoE = mlcs.remove_from_bi_fid_doe(X=X, DoE=DoE)
-    assert X not in DoE.high and X not in DoE.low
+    doe = mlcs.bi_fidelity_doe(2, 5, 10)
+    X = doe.high[3]
+    assert X in doe.high and X in doe.low
+    doe = mlcs.remove_from_bi_fid_doe(X=X, doe=doe)
+    assert X not in doe.high and X not in doe.low
 
 
 # split_bi_fidelity_doe
 def test_split_bifiddoe_errors():
-    DoE = mlcs.bi_fidelity_doe(2, 5, 10)
+    doe = mlcs.bi_fidelity_doe(2, 5, 10)
     # invalid num_high
     with raises(ValueError):
-        mlcs.split_bi_fidelity_doe(DoE, -1, 7)
+        mlcs.split_bi_fidelity_doe(doe, -1, 7)
     with raises(ValueError):
-        mlcs.split_bi_fidelity_doe(DoE, 6, 7)
+        mlcs.split_bi_fidelity_doe(doe, 6, 7)
 
     # invalid num_low
     with raises(ValueError):
-        mlcs.split_bi_fidelity_doe(DoE, 3, 11)
+        mlcs.split_bi_fidelity_doe(doe, 3, 11)
 
     # # invalid comparison
     with raises(ValueError):
-        mlcs.split_bi_fidelity_doe(DoE, 4, 3)
+        mlcs.split_bi_fidelity_doe(doe, 4, 3)
 
 
 def test_split_bifiddoe_warnings():
-    DoE = mlcs.bi_fidelity_doe(2, 5, 10)
+    doe = mlcs.bi_fidelity_doe(2, 5, 10)
 
     # not enough high-fid
     with warns(mlcs.LowHighFidSamplesWarning):
-        mlcs.split_bi_fidelity_doe(DoE, 0, 3)
+        mlcs.split_bi_fidelity_doe(doe, 0, 3)
     with warns(mlcs.LowHighFidSamplesWarning):
-        mlcs.split_bi_fidelity_doe(DoE, 1, 3)
+        mlcs.split_bi_fidelity_doe(doe, 1, 3)
 
     # no high-fid samples in test-set
     with warns(mlcs.NoHighFidTrainSamplesWarning):
-        mlcs.split_bi_fidelity_doe(DoE, 5, 7)
+        mlcs.split_bi_fidelity_doe(doe, 5, 7)
 
     # no non-high-fidelity low-fidelity samples in test set
     with warns(mlcs.NoSpareLowFidSamplesWarning):
-        mlcs.split_bi_fidelity_doe(DoE, 3, 3)
+        mlcs.split_bi_fidelity_doe(doe, 3, 3)
 
 
 def test_split_bifiddoe():
-    DoE = mlcs.bi_fidelity_doe(2, 5, 10)
+    doe = mlcs.bi_fidelity_doe(2, 5, 10)
 
     a_high, a_low = 3, 7
-    a, b = mlcs.split_bi_fidelity_doe(DoE, 3, 7)
+    a, b = mlcs.split_bi_fidelity_doe(doe, 3, 7)
 
     assert len(a.low) == a_low
     assert len(a.high) == a_high
-    assert len(a.low) + len(b.low) == len(DoE.low)
-    assert len(a.high) + len(b.high) == len(DoE.high)
+    assert len(a.low) + len(b.low) == len(doe.low)
+    assert len(a.high) + len(b.high) == len(doe.high)
 
 
 def test_valueerror_split_bifiddoe():


### PR DESCRIPTION
As part of this reimplementation:
- CandidateArchive tests have been rewritten to focus invariant behavior properties (although not [yet] using `hypothesis`)
- the internal representation is changed to be more 'database-like', by storing one object per candidate
- fidelities per candidate are recorded dynamically instead of pre-allocated
- 