### PR TITLE
Improve mfbo optimizer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
+        pip install .
     - name: Test with pytest
       run: |
         pytest

--- a/multiLevelCoSurrogates/utils/__init__.py
+++ b/multiLevelCoSurrogates/utils/__init__.py
@@ -1,3 +1,4 @@
+from .error_grids import *
 from .pathing import *
 from .plotting import *
 from .sampling import *

--- a/multiLevelCoSurrogates/utils/error_grids.py
+++ b/multiLevelCoSurrogates/utils/error_grids.py
@@ -1,0 +1,75 @@
+from collections import namedtuple
+
+import numpy as np
+from sklearn.linear_model import LinearRegression
+import xarray as xr
+
+import multiLevelCoSurrogates as mlcs
+
+
+def fit_lin_reg(da: xr.DataArray, calc_SSE: bool=False):
+    """Determine linear regression coefficients after training index -> value"""
+
+    series = da.to_series().dropna()
+    X = np.array(series.index.tolist())[:,:2]  # remove rep_idx (3rd column)
+    y = np.log10(series.values)
+    reg = LinearRegression().fit(X, y)
+
+    if not calc_SSE:
+        return reg
+
+    pred_y = reg.predict(X)
+    SSE = np.sum((pred_y - y)**2)
+    return reg, SSE
+
+
+def calc_angle(da: xr.DataArray):
+    """Calculate the global gradient angle of an Error Grid based
+    on the slope of beta_1 / beta_2 from a linear regression fit.
+    """
+    AngleSummary = namedtuple('AngleSummary', 'alpha beta theta deg deg_low deg_high')
+    reg, SSE = mlcs.utils.error_grids.fit_lin_reg(da, calc_SSE=True)
+
+    beta_high, beta_low = reg.coef_
+    ratio = beta_high / beta_low
+    df = da.size - 3
+
+    nhighs = da.coords['n_high'].values
+    var_nhigh = np.sqrt(np.sum((nhighs - np.mean(nhighs))**2))
+
+    nlows = da.coords['n_low'].values
+    var_nlow = np.sqrt(np.sum((nlows - np.mean(nlows))**2))
+
+    s = np.sqrt(SSE / df)
+
+    se_nhigh = s / var_nhigh
+    se_nlow = s / var_nlow
+    se_ratio = np.sqrt((se_nhigh / beta_high)**2 + (se_nlow / beta_low)**2)
+
+    ci_beta_high = ConfidenceInterval(beta_high, se_nhigh, beta_high-1.96*se_nhigh, beta_high+1.96*se_nhigh)
+    ci_beta_low = ConfidenceInterval(beta_low, se_nlow, beta_low-1.96*se_nlow, beta_low+1.96*se_nlow)
+    ci_beta_ratio = ConfidenceInterval(ratio, se_ratio, ratio-1.96*se_ratio, ratio+1.96*se_ratio)
+
+    theta = np.arctan(ratio)
+    mid_angle = np.rad2deg(theta)
+
+    min_angle = np.rad2deg(np.arctan(ci_beta_ratio.lower))
+    max_angle = np.rad2deg(np.arctan(ci_beta_ratio.upper))
+    if mid_angle < 0:
+        min_angle, mid_angle, max_angle = min_angle+180, mid_angle+180, max_angle+180
+    elif mid_angle > 180:
+        min_angle, mid_angle, max_angle = min_angle-180, mid_angle-180, max_angle-180
+
+    return AngleSummary(beta_high, beta_low, theta, mid_angle, min_angle, max_angle)
+
+
+class ConfidenceInterval(namedtuple('ConfidenceInterval', 'mean se lower upper')):
+
+    def __contains__(self, value: float):
+        return self.lower < value < self.upper
+
+    def __str__(self):
+        lower = self.lower if self.lower is not None else self.mean - 1.96*self.se
+        upper = self.upper if self.upper is not None else self.mean + 1.96*self.se
+        return f'95% CI: {self.mean:.4f} +/- {1.96*self.se:.4f} {np.array([lower, upper])}: ' \
+               f'H0{" not" if 0 in self else ""} rejected'

--- a/scripts/experiments/2020-11-05-simple-mfbo.py
+++ b/scripts/experiments/2020-11-05-simple-mfbo.py
@@ -320,6 +320,10 @@ class Optimizer:
 
     def select_fidelity(self):
 
+        if self.budget <= 1:
+            return 'high'
+        if self.budget <= 2:
+            return 'low'
         if self.archive.count('high') >= self.archive.count('low'):
             return 'low'
 

--- a/scripts/experiments/experiments.py
+++ b/scripts/experiments/experiments.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-import sys
 from datetime import datetime
 from collections import namedtuple
 from functools import partial
@@ -13,13 +12,8 @@ import mf2
 import numpy as np
 import xarray as xr
 from parse import parse
-from pyprojroot import here
 from sklearn.metrics import mean_squared_error, r2_score
 from mf2 import MultiFidelityFunction
-
-module_path = str(here())
-if module_path not in sys.path:
-    sys.path.append(module_path)
 
 import multiLevelCoSurrogates as mlcs
 

--- a/scripts/processing/2020-09-18-angle-match-matrices.py
+++ b/scripts/processing/2020-09-18-angle-match-matrices.py
@@ -7,14 +7,13 @@ from using different surrogate models, and plot them as 'heatmaps'.
 """
 
 import argparse
-from collections import namedtuple
-from enum import IntEnum
 from itertools import combinations
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 from pyprojroot import here
+
+import multiLevelCoSurrogates as mlcs
 
 import processing as proc
 
@@ -88,7 +87,7 @@ def plot_model_match_angles(df_kriging, df_non_kriging):
 
 
 def get_CI(row):
-    return proc.ConfidenceInterval(row['deg'], None, row['deg_low'], row['deg_high'])
+    return mlcs.utils.error_grids.ConfidenceInterval(row['deg'], None, row['deg_low'], row['deg_high'])
 
 
 if __name__ == '__main__':

--- a/scripts/processing/2020-09-28-shape-reduction.py
+++ b/scripts/processing/2020-09-28-shape-reduction.py
@@ -17,6 +17,7 @@ import xarray as xr
 from pathlib import Path
 from pyprojroot import here
 
+import multiLevelCoSurrogates as mlcs
 import processing as proc
 
 print(f'Running script: {__file__}')
@@ -74,7 +75,7 @@ def calculate_gradients_of_reduced(da: xr.DataArray, reduction_options: dict) ->
     """
 
     results = [
-        proc.calc_angle(reduce_size(da, *options))
+        mlcs.utils.error_grids.calc_angle(reduce_size(da, *options))
         for options in product(*reduction_options.values())
     ]
 

--- a/scripts/processing/2020-11-16-simple-mfbo.py
+++ b/scripts/processing/2020-11-16-simple-mfbo.py
@@ -26,7 +26,6 @@ if module_path not in sys.path:
     sys.path.append(module_path)
 
 import multiLevelCoSurrogates as mlcs
-from multiLevelCoSurrogates import CandidateArchive
 
 data_path = here('files/2020-11-05-simple-mfbo/')
 plot_path = here('plots/2020-11-16-simple-mfbo/', warn=False)


### PR DESCRIPTION
Two main improvements:
 - [x] Fidelity selection now takes the remaining budget into account: optimization should finish with a high-fidelity evaluation, and 'use up' all remaining budget with low-fidelity evaluations before that
 - [x] Refactoring functions related to calculating the angle of an Error Grid into the utils part of the 'mlcs' library, instead of being duplicated in both `processing` and `experiments`

Also:
- [x] cleanup of `sys.path.append` stuff since `mlcs` can now be installed as a local package
- [x] further cleanup of unused imports