### PR TITLE
Plot archive with CandidateArchive.undo_last()

### DIFF
--- a/multiLevelCoSurrogates/candidate_archive.py
+++ b/multiLevelCoSurrogates/candidate_archive.py
@@ -219,7 +219,7 @@ class CandidateArchive:
         np.savez(file, **save_args)
 
 
-    def undo_last(self):
+    def undo_last(self, fidelity=None):
         """Undo the latest addition to the archive
 
         This only undoes additions. If a value has been first added and then
@@ -227,9 +227,18 @@ class CandidateArchive:
         Undone actions also cannot be replayed, so be sure to have an original
         copy (saved) and use with care.
         """
-        idx, fid = self._update_history.pop(-1)
-        assert self.candidates[idx].idx == idx  # runtime sanity check
-        del self.candidates[idx].fidelities[fid]
+        # If no fidelity is specified, simply select the last one to undo
+        # TODO: deal more nicely with 'None' in list of fidelities, just confusing now...
+        if fidelity is None and len(self.fidelities) > 1:
+            fidelity = self._update_history[-1][1]
+
+        while True:  # do-while
+            idx, fid = self._update_history.pop(-1)
+            assert self.candidates[idx].idx == idx  # runtime sanity check
+            del self.candidates[idx].fidelities[fid]
+
+            if fid == fidelity:
+                break
 
 
     def _updateminmax(self, value: float, fidelity: str=None):

--- a/multiLevelCoSurrogates/candidate_archive.py
+++ b/multiLevelCoSurrogates/candidate_archive.py
@@ -219,7 +219,7 @@ class CandidateArchive:
         np.savez(file, **save_args)
 
 
-    def undo_last(self, fidelity=None):
+    def undo_last(self, *, fidelity=None):
         """Undo the latest addition to the archive
 
         This only undoes additions. If a value has been first added and then
@@ -231,6 +231,9 @@ class CandidateArchive:
         # TODO: deal more nicely with 'None' in list of fidelities, just confusing now...
         if fidelity is None and len(self.fidelities) > 1:
             fidelity = self._update_history[-1][1]
+
+        if fidelity not in self.fidelities:
+            raise ValueError(f'Specified fidelity `{fidelity}` is not in archive.')
 
         while True:  # do-while
             idx, fid = self._update_history.pop(-1)

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -279,3 +279,18 @@ def test_undo_last_overwritten():
     archive.undo_last()
     assert archive.count('A') == 1
     assert archive.count('B') == 1
+
+
+def test_undo_last_specify_fidelity():
+    archive = CandidateArchive()
+    fidelity_order = 'AABBBBBAA'
+    for fid in fidelity_order:
+        archive.addcandidate(np.random.rand(2), np.random.rand(), fidelity=fid)
+
+    archive.undo_last(fidelity='B')
+    assert archive.count('A') == 2
+    assert archive.count('B') == 4
+
+    archive.undo_last(fidelity='A')
+    assert archive.count('A') == 1
+    assert archive.count('B') == 0

--- a/tests/test_CandidateArchive.py
+++ b/tests/test_CandidateArchive.py
@@ -294,3 +294,14 @@ def test_undo_last_specify_fidelity():
     archive.undo_last(fidelity='A')
     assert archive.count('A') == 1
     assert archive.count('B') == 0
+
+
+def test_undo_last_incorrect_fidelity():
+
+    archive = CandidateArchive()
+    fidelity_order = 'AABB'
+    for fid in fidelity_order:
+        archive.addcandidate(np.random.rand(2), np.random.rand(), fidelity=fid)
+
+    with pytest.raises(ValueError):
+        archive.undo_last(fidelity='C')


### PR DESCRIPTION
Now `_update_history` is being tracked, it is no longer needed to store a separate file at every iteration, but the final file can simply be used to replay the process in reverse order. This is now implemented in the relevant processing script